### PR TITLE
chore(MKT-133): Deprecating the old m1 webhooks

### DIFF
--- a/v1/packages/medusa-plugin-webhooks/README.md
+++ b/v1/packages/medusa-plugin-webhooks/README.md
@@ -1,0 +1,3 @@
+# Medusa Webhooks Plugin
+
+Deprecated: Please check out the new Medusa2 plugin instead: https://www.npmjs.com/package/@lambdacurry/medusa-webhooks

--- a/v1/packages/medusa-plugin-webhooks/package.json
+++ b/v1/packages/medusa-plugin-webhooks/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@lambdacurry/medusa-plugin-webhooks",
+  "description": "Medusa Markethaus Webhooks",
+  "version": "2.0.0-deprecated",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "cross-env rm -rf ./dist && tsc --build && npm run build:server && npm run build:admin",
+    "dev": "tsc-watch --build --watch --verbose --force --onSuccess \"yarn prepare\"",
+    "watch": "tsc --build --watch & yarn prepare",
+    "build:server": "cross-env tsc -p tsconfig.server.json",
+    "build:admin": "cross-env tsc -p tsconfig.admin.json",
+    "publish-to-npm": "npm run build && npm publish --access public"
+  },
+  "dependencies": {
+    "@medusajs/admin": "7.1.16",
+    "@medusajs/medusa": "1.20.9",
+    "cross-env": "^7.0.3",
+    "medusa-core-utils": "^1.2.1",
+    "node-fetch": "2.6.6",
+    "typeorm": "^0.3.20",
+    "typescript": "5.5.4",
+    "util": "^0.12.5"
+  },
+  "browser": {
+    "util": false
+  },
+  "devDependencies": {
+    "tsc-watch": "^6.2.0"
+  }
+}

--- a/v1/packages/medusa-plugin-webhooks/src/admin/components/atoms/Spinner.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/components/atoms/Spinner.tsx
@@ -1,0 +1,34 @@
+import clsx from 'clsx';
+import React from 'react';
+
+export type SpinnerProps = {
+  size?: 'xlarge' | 'large' | 'medium' | 'small' | 'xsmall';
+  variant?: 'primary' | 'secondary';
+};
+
+const Spinner: React.FC<SpinnerProps> = ({ size = 'large', variant = 'primary' }) => {
+  return (
+    <div
+      className={clsx(
+        'flex items-center justify-center',
+        { 'h-[32px] w-[32px]': size === 'xlarge' },
+        { 'h-[24px] w-[24px]': size === 'large' },
+        { 'h-[20px] w-[20px]': size === 'medium' },
+        { 'h-[16px] w-[16px]': size === 'small' },
+        { 'h-[16px] w-[16px]': size === 'xsmall' },
+      )}
+    >
+      <div className="relative flex h-full w-full items-center justify-center">
+        <div
+          className={clsx(
+            'animate-ring rounded-circle h-4/5 w-4/5 border-2 border-transparent',
+            { 'border-t-grey-0': variant === 'primary' },
+            { 'border-t-violet-60': variant === 'secondary' },
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Spinner;

--- a/v1/packages/medusa-plugin-webhooks/src/admin/components/fundamentals/status-indicator/index.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/components/fundamentals/status-indicator/index.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx';
+import React from 'react';
+
+type StatusIndicatorProps = {
+  title?: string;
+  variant: 'primary' | 'danger' | 'warning' | 'success' | 'active' | 'default';
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const StatusIndicator: React.FC<StatusIndicatorProps> = ({ title, variant = 'success', className, ...props }) => {
+  const dotClass = clsx({
+    'bg-teal-50': variant === 'success',
+    'bg-rose-50': variant === 'danger',
+    'bg-yellow-50': variant === 'warning',
+    'bg-violet-60': variant === 'primary',
+    'bg-emerald-40': variant === 'active',
+    'bg-grey-40': variant === 'default',
+  });
+  return (
+    <div
+      className={clsx('inter-small-regular flex items-center', className, {
+        'hover:bg-grey-5 cursor-pointer': !!props.onClick,
+      })}
+      {...props}
+    >
+      <div className={clsx('h-1.5 w-1.5 self-center rounded-full', dotClass)} />
+      {title && <span className="ml-2">{title.charAt(0).toUpperCase() + title.slice(1)}</span>}
+    </div>
+  );
+};
+
+export default StatusIndicator;

--- a/v1/packages/medusa-plugin-webhooks/src/admin/components/molecules/Actionables.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/components/molecules/Actionables.tsx
@@ -1,0 +1,95 @@
+import { EllipsisHorizontal } from '@medusajs/icons';
+import { Button, DropdownMenu, clx } from '@medusajs/ui';
+import type { FC, MouseEvent, ReactNode } from 'react';
+
+export interface Actionable {
+  label: string;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+  icon?: ReactNode;
+  variant?: 'normal' | 'danger';
+}
+
+type ActionablesProps = {
+  actions?: Actionable[];
+  customTrigger?: ReactNode;
+  forceDropdown?: boolean;
+};
+
+const Actionables: FC<ActionablesProps> = ({ actions, customTrigger, forceDropdown = false }) => {
+  if (actions && (forceDropdown || actions.length > 1)) {
+    return (
+      <div>
+        <DropdownMenu modal={false}>
+          <DropdownMenu.Trigger asChild>
+            {!customTrigger ? (
+              <Button
+                className="h-xlarge px-1 w-xlarge focus-visible:shadow-input focus-visible:border-violet-60 focus:shadow-none focus-visible:outline-none"
+                size="small"
+                variant="transparent"
+              >
+                <EllipsisHorizontal />
+              </Button>
+            ) : (
+              customTrigger
+            )}
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content
+            className="bg-grey-0 border border-grey-20 min-w-[200px] p-xsmall rounded-rounded shadow-dropdown z-30"
+            sideOffset={5}
+          >
+            {actions.map((action, index) => (
+              <DropdownMenu.Item key={index} className="mb-1 last:mb-0">
+                <Button
+                  className={clx('flex justify-start w-full', {
+                    'text-rose-50': action?.variant === 'danger',
+                    'opacity-50 pointer-events-none select-none': action?.disabled,
+                  })}
+                  size="small"
+                  variant="transparent"
+                  onClick={action?.onClick}
+                >
+                  {action.icon}
+                  {action.label}
+                </Button>
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </div>
+    );
+  }
+
+  if (customTrigger) {
+    const triggers = Array.isArray(customTrigger) ? customTrigger : [customTrigger];
+
+    return (
+      <div>
+        {triggers.map((trigger, index) => (
+          <div key={index}>{trigger}</div>
+        ))}
+      </div>
+    );
+  }
+
+  const [action] = actions ?? [];
+
+  if (action) {
+    return (
+      <div>
+        <Button className="flex items-center" size="small" type="button" variant="transparent" onClick={action.onClick}>
+          {!action.icon ? (
+            action.label
+          ) : (
+            <div className="flex gap-x-2xsmall items-center">
+              {action.icon}
+              {action.label}
+            </div>
+          )}
+        </Button>
+      </div>
+    );
+  }
+};
+
+export default Actionables;

--- a/v1/packages/medusa-plugin-webhooks/src/admin/components/molecules/Modal.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/components/molecules/Modal.tsx
@@ -1,0 +1,155 @@
+import { XMark } from '@medusajs/icons';
+import { Button } from '@medusajs/ui';
+import * as Dialog from '@radix-ui/react-dialog';
+import * as Portal from '@radix-ui/react-portal';
+import clsx from 'clsx';
+import React from 'react';
+
+import { useWindowDimensions } from '../../hooks/use-window-dimensions';
+
+type ModalState = {
+  portalRef: React.RefObject<HTMLDivElement> | undefined;
+  isLargeModal?: boolean;
+};
+
+export const ModalContext = React.createContext<ModalState>({
+  portalRef: undefined,
+  isLargeModal: true,
+});
+
+export type ModalProps = {
+  isLargeModal?: boolean;
+  handleClose: () => void;
+  open?: boolean;
+  children?: React.ReactNode;
+};
+
+type ModalChildProps = {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+};
+
+type ModalHeaderProps = {
+  handleClose: () => void;
+  children?: React.ReactNode;
+};
+
+type ModalType = React.FC<ModalProps> & {
+  Body: React.FC<ModalChildProps>;
+  Header: React.FC<ModalHeaderProps>;
+  Footer: React.FC<ModalChildProps>;
+  Content: React.FC<ModalChildProps>;
+};
+
+const Overlay: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <Dialog.Overlay className="bg-grey-90/40 fixed top-0 bottom-0 left-0 right-0 z-50 grid place-items-center overflow-y-auto">
+      {children}
+    </Dialog.Overlay>
+  );
+};
+
+const Content: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { height } = useWindowDimensions();
+  const style = {
+    maxHeight: height - 64,
+  };
+  return (
+    <Dialog.Content style={style} className="min-w-modal rounded-rounded bg-grey-0 overflow-x-hidden">
+      {children}
+    </Dialog.Content>
+  );
+};
+
+const Modal: ModalType = ({ open = true, handleClose, isLargeModal = true, children }) => {
+  const portalRef = React.useRef(null);
+  return (
+    <Dialog.Root open={open} onOpenChange={handleClose}>
+      <div className="hidden">
+        <Dialog.Title>this is only to suppress a error</Dialog.Title>
+        <Dialog.Description> this is only to suppress a warning</Dialog.Description>
+      </div>
+      <Portal.Portal ref={portalRef}>
+        <ModalContext.Provider value={{ portalRef, isLargeModal }}>
+          <Overlay>
+            <Content>{children}</Content>
+          </Overlay>
+        </ModalContext.Provider>
+      </Portal.Portal>
+    </Dialog.Root>
+  );
+};
+
+Modal.Body = ({ children, className, style }) => {
+  return (
+    <div style={style} className={clsx('inter-base-regular h-full', className)} onClick={(e) => e.stopPropagation()}>
+      {children}
+    </div>
+  );
+};
+
+Modal.Content = ({ children, className }) => {
+  const { isLargeModal } = React.useContext(ModalContext);
+
+  const { height } = useWindowDimensions();
+  const style = {
+    maxHeight: height - 90 - 141,
+  };
+  return (
+    <div
+      style={style}
+      className={clsx(
+        'overflow-y-auto px-8 pt-6',
+        {
+          ['w-largeModal pb-7']: isLargeModal,
+          ['pb-5']: !isLargeModal,
+        },
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+Modal.Header = ({ handleClose = undefined, children }) => {
+  return (
+    <div className="flex w-full items-center border-b px-8 py-6" onClick={(e) => e.stopPropagation()}>
+      <div className="flex flex-grow">{children}</div>
+      <div className="self-end">
+        {handleClose && (
+          <Button
+            variant="transparent"
+            size="small"
+            onClick={handleClose}
+            className="text-grey-50 cursor-pointer border p-1.5"
+          >
+            <XMark width={20} height={20} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+Modal.Footer = ({ children, className }) => {
+  const { isLargeModal } = React.useContext(ModalContext);
+
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      className={clsx(
+        'bottom-0 flex w-full px-7 pb-5',
+        {
+          'border-grey-20 border-t pt-4': isLargeModal,
+        },
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Modal;

--- a/v1/packages/medusa-plugin-webhooks/src/admin/components/molecules/WebhooksTable.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/components/molecules/WebhooksTable.tsx
@@ -1,0 +1,145 @@
+import { ColumnDef } from "@tanstack/react-table";
+import React, { useMemo, useState } from "react";
+
+import { useAdminWebhooks } from "../../hooks/webhooks/queries";
+import { DataTable } from "../organisms/data-table";
+import { Webhook } from "../../../models";
+import Actionables from "./Actionables";
+import { Pencil, Trash } from "@medusajs/icons";
+import StatusIndicator from "../fundamentals/status-indicator";
+
+interface WebhooksTableProps {
+  setRefreshTable: (callback: () => void | null) => void;
+  editWebhookModal: (webhook: Webhook) => void;
+  deleteWebooksModal: (webhook: Webhook) => void;
+}
+
+export const columnsDef = ({
+  editWebhookModal,
+  deleteWebooksModal,
+}: {
+  editWebhookModal: (webhook: Webhook) => void;
+  deleteWebooksModal: (webhook: Webhook) => void;
+}): ColumnDef<Webhook>[] => [
+  {
+    accessorKey: "event_type",
+    header: "Event Type",
+  },
+  {
+    accessorKey: "target_url",
+    header: "Target URL",
+  },
+  {
+    header: "Status",
+    cell: ({ row }) => {
+      const finalStatus: {
+        title: string;
+        variant: "active" | "danger";
+      } = row.original.active
+        ? {
+            title: "Active",
+            variant: "active",
+          }
+        : {
+            title: "Inactive",
+            variant: "danger",
+          };
+
+      return (
+        <>
+          <StatusIndicator
+            title={finalStatus.title}
+            variant={finalStatus.variant}
+          />
+          {row.original.active}
+        </>
+      );
+    },
+  },
+  {
+    header: "Actions",
+    cell: ({ row }) => {
+      return (
+        <Actionables
+          actions={[
+            {
+              label: "Edit",
+              onClick: () => editWebhookModal(row.original),
+              icon: <Pencil />,
+            },
+            {
+              label: "Delete",
+              onClick: () => deleteWebooksModal(row.original),
+              icon: <Trash />,
+            },
+          ]}
+        />
+      );
+    },
+  },
+];
+
+export const WebhooksTable: React.FC<WebhooksTableProps> = ({
+  setRefreshTable,
+  deleteWebooksModal,
+  editWebhookModal,
+}) => {
+  const columns = useMemo(() => {
+    return columnsDef({
+      deleteWebooksModal,
+      editWebhookModal,
+    });
+  }, [deleteWebooksModal, editWebhookModal]);
+
+  const [paginationState, setPaginationState] = useState({
+    pageSize: 20,
+    pageIndex: 0,
+  });
+
+  const { data: subscriptionsData, refetch: refetchWebhooks } =
+    useAdminWebhooks({
+      limit: paginationState.pageSize,
+      offset: paginationState.pageIndex * paginationState.pageSize,
+    });
+
+  const [subscriptions, totalCount] = subscriptionsData?.subscriptions ?? [];
+
+  React.useEffect(() => {
+    setRefreshTable(() => refetchWebhooks);
+  }, [refetchWebhooks, setRefreshTable]);
+
+  if (totalCount === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64">
+        <button
+          onClick={() => editWebhookModal({} as Webhook)}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+          type="button"
+        >
+          Create New Webhook
+        </button>
+      </div>
+    );
+  }
+
+  if (!subscriptions?.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        data={subscriptions}
+        totalRecords={totalCount}
+        pagination={paginationState}
+        onPaginationChange={(updater) => {
+          const update =
+            typeof updater === "function" ? updater(paginationState) : updater;
+
+          setPaginationState(update);
+        }}
+      />
+    </>
+  );
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/components/organisms/data-table/index.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/components/organisms/data-table/index.tsx
@@ -1,0 +1,121 @@
+import { Table, clx } from "@medusajs/ui"
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  PaginationState,
+  OnChangeFn,
+  TableState,
+} from "@tanstack/react-table"
+
+export interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  className?: string
+  onPaginationChange?: OnChangeFn<PaginationState>
+  onSortingChange?: OnChangeFn<SortingState>
+  pagination?: TableState["pagination"]
+  totalRecords: number
+  manualPagination?: boolean
+  manualSorting?: boolean
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  className,
+  onPaginationChange,
+  onSortingChange,
+  totalRecords,
+  pagination,
+  manualPagination = true,
+  manualSorting = true,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: onSortingChange,
+    getSortedRowModel: getSortedRowModel(),
+    onPaginationChange: onPaginationChange,
+    manualPagination,
+    manualSorting,
+  })
+
+  return (
+    <>
+      <div className={clx(className, "block  border-x")}>
+        <Table>
+          <Table.Header>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <Table.Row key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <Table.HeaderCell key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </Table.HeaderCell>
+                  )
+                })}
+              </Table.Row>
+            ))}
+          </Table.Header>
+          <Table.Body>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <Table.Row
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  className={(row.original as any)?.className ?? ""}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <Table.Cell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </Table.Cell>
+                  ))}
+                </Table.Row>
+              ))
+            ) : (
+              <Table.Row>
+                <Table.Cell
+                  // @ts-ignore
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </Table.Cell>
+              </Table.Row>
+            )}
+          </Table.Body>
+        </Table>
+      </div>
+      {!!pagination && (
+        <Table.Pagination
+          className="mt-2"
+          count={totalRecords}
+          pageSize={pagination.pageSize}
+          pageIndex={pagination.pageIndex}
+          canPreviousPage={pagination.pageIndex != 0}
+          canNextPage={
+            (pagination.pageIndex + 1) * pagination.pageSize < totalRecords
+          }
+          pageCount={Math.ceil(totalRecords / pagination.pageSize)}
+          previousPage={() => table.previousPage()}
+          nextPage={() => table.nextPage()}
+        />
+      )}
+    </>
+  )
+}

--- a/v1/packages/medusa-plugin-webhooks/src/admin/hooks/use-window-dimensions.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/hooks/use-window-dimensions.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+// @ts-ignore
+const window = typeof window !== "undefined" ? window : {};
+
+export const useWindowDimensions = () => {
+  if (typeof window === "undefined") {
+    return {
+      height: 0,
+      width: 0,
+    };
+  }
+
+  const [dimensions, setDimensions] = useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      });
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return dimensions;
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/hooks/webhooks/mutations.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/hooks/webhooks/mutations.ts
@@ -1,0 +1,31 @@
+import { useAdminCustomPost, useAdminCustomDelete, useAdminCustomQuery } from 'medusa-react';
+import { EventOptions } from '../../../api/admin/webhooks/events/route';
+
+export interface Webhook {
+  id: string;
+  event_type: string;
+  active: boolean;
+  target_url: string;
+}
+
+export type WebhookTestPayload = Pick<Webhook, 'event_type' | 'target_url'>;
+
+export const useAdminCreateWebhook = () => {
+  return useAdminCustomPost<null, Webhook>(`/admin/webhooks`, ['webhooks']);
+};
+
+export const useAdminUpdateWebhook = (id?: string) => {
+  return useAdminCustomPost<Partial<Webhook>, Webhook>(`/admin/webhooks/${id}`, ['webhooks', id]);
+};
+
+export const useAdminDeleteWebhook = (id: string) => {
+  return useAdminCustomDelete<null>(`/admin/webhooks/${id}`, ['webhooks', id]);
+};
+
+export const useAdminTestWebhook = () => {
+  return useAdminCustomPost<WebhookTestPayload, Response>(`/admin/webhooks/test`, ['webhooks', 'test']);
+};
+
+export const useAdminGetWebhookEvents = () => {
+  return useAdminCustomQuery<{ options: EventOptions[] }>('/admin/webhooks/events', ['webhooks', 'events']);
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/hooks/webhooks/queries.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/hooks/webhooks/queries.ts
@@ -1,0 +1,30 @@
+import { Response } from '@medusajs/medusa-js';
+import { Webhook } from '../../../models/webhook';
+import qs from 'qs';
+import { useAdminCustomQuery } from 'medusa-react';
+
+const WEBHOOK_QUERY_KEY = [`mkt_webhooks`];
+
+export class AdminGetWebhooksParameter {
+  offset = 0;
+  limit = 50;
+  expand?: string;
+  fields?: string;
+}
+
+export interface AdminVendorWebhookRes {
+  email: string;
+  role: string;
+  access_level: string;
+}
+
+export const useAdminWebhooks = (query?: AdminGetWebhooksParameter) => {
+  const queryString = qs.stringify(query);
+  const queryKey = [...WEBHOOK_QUERY_KEY, queryString];
+
+  const path = `/admin/webhooks?${queryString}`;
+
+  return useAdminCustomQuery<undefined, { subscriptions: [Webhook[], number] }>(path, queryKey, null, {
+    keepPreviousData: true,
+  });
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/modals/webhook-delete-modal.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/modals/webhook-delete-modal.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useAdminDeleteWebhook } from '../hooks/webhooks/mutations';
+import { Button, toast } from '@medusajs/ui';
+import { Webhook } from '../../models';
+import Modal from '../components/molecules/Modal';
+
+type WebhookModalProps = {
+  onClose: () => void;
+  webhook: Webhook;
+};
+
+export const WebhookDeleteModal: React.FC<WebhookModalProps> = ({ onClose, webhook }) => {
+  const deleteWebhook = useAdminDeleteWebhook(webhook.id);
+
+  const handleDelete = () => {
+    deleteWebhook.mutate(null, {
+      onSuccess: () => {
+        toast.success('Success', {
+          description: 'Webhook removed',
+        });
+        onClose();
+      },
+      onError: (error) => {
+        toast.error('Error', {
+          description: 'Webhook Deletion Failed',
+        });
+        console.error(error);
+        onClose();
+      },
+    });
+  };
+  return (
+    <Modal handleClose={onClose}>
+      <Modal.Body>
+        <Modal.Header handleClose={onClose}>
+          <div>
+            <h1 className="inter-xlarge-semibold mb-2xsmall">Delete Webhook</h1>
+          </div>
+        </Modal.Header>
+        <Modal.Content>
+          <h2 className="inter-base-semibold mb-base">
+            Are you sure you want to delete: {webhook?.event_type} {'->'}
+            {webhook?.target_url}?
+          </h2>
+        </Modal.Content>
+        <Modal.Footer>
+          <div className="flex w-full items-center justify-end gap-2">
+            <Button variant="secondary" size="small" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleDelete} variant="danger" size="small">
+              Delete Webhook
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal.Body>
+    </Modal>
+  );
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/modals/webhook-modal.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/modals/webhook-modal.tsx
@@ -1,0 +1,200 @@
+import React, { useState } from 'react';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { Button, Switch, Select, Input, toast } from '@medusajs/ui';
+import Modal from '../components/molecules/Modal';
+import { Webhook } from '../../models';
+import { useAdminCreateWebhook, useAdminGetWebhookEvents, useAdminUpdateWebhook } from '../hooks/webhooks/mutations';
+import { WebhookTestModal } from './webhook-test-modal';
+import { getErrorMessage } from '../utils/error-messages';
+
+type WebhookModalProps = {
+  onClose: () => void;
+  onSuccess?: (values: Webhook) => void;
+  webhook?: Webhook | null;
+};
+
+interface WebhookForm {
+  event_type: { label: string; value: string };
+  target_url: string;
+  active: boolean;
+}
+
+const defaultValues: WebhookForm = {
+  event_type: { label: '', value: '' },
+  target_url: '',
+  active: true,
+};
+
+export const WebhookModal: React.FC<WebhookModalProps> = ({ onClose, onSuccess, webhook }) => {
+  const form = useForm<WebhookForm>({
+    defaultValues: webhook
+      ? {
+          ...webhook,
+          event_type: { label: webhook.event_type, value: webhook.event_type },
+        }
+      : defaultValues,
+    mode: 'onChange',
+  });
+  const { register, handleSubmit, control, formState } = form;
+
+  const [openTestModal, setTestModalState] = useState<boolean>(false);
+
+  const createWebhook = useAdminCreateWebhook();
+  const updateWebhook = useAdminUpdateWebhook(webhook?.id);
+  const getWebhookEvents = useAdminGetWebhookEvents();
+
+  const formIsValid = formState.isValid;
+
+  const submitForm = (formData: WebhookForm) => {
+    const data: Partial<Webhook> = {
+      target_url: formData.target_url,
+      active: formData.active,
+      event_type: formData.event_type.value,
+    };
+
+    if (webhook) {
+      data.id = webhook.id;
+    }
+
+    const mutation = webhook
+      ? { mutate: updateWebhook.mutate, successMessage: 'Webhook Updated' }
+      : { mutate: createWebhook.mutate, successMessage: 'Webhook Created' };
+
+    return mutation.mutate(data, {
+      onSuccess: (data: any) => {
+        toast.success('Success', {
+          description: mutation.successMessage,
+        });
+
+        if (onSuccess) onSuccess(data);
+        onClose();
+      },
+      onError: (error: any) => {
+        toast.error('Error', {
+          description: getErrorMessage(error),
+        });
+      },
+    });
+  };
+
+  const closeTestModal = () => {
+    setTestModalState(false);
+  };
+
+  const options = getWebhookEvents?.data?.options ?? [];
+
+  return (
+    <>
+      <Modal handleClose={onClose}>
+        <Modal.Body>
+          <Modal.Header handleClose={onClose}>
+            <div>
+              <h1 className="inter-xlarge-semibold mb-2xsmall">{webhook ? `Edit Webhook` : 'Add Webhook'}</h1>
+            </div>
+          </Modal.Header>
+          <FormProvider {...form}>
+            <form onSubmit={handleSubmit(submitForm)}>
+              <Modal.Content>
+                <div>
+                  <div>
+                    <div className="small:grid-cols-[1fr_2fr] mb-4 grid grid-cols-1 gap-2">
+                      <div className="gap-y-2xsmall flex flex-col" style={{ zIndex: 100 }}>
+                        <Controller
+                          name="event_type"
+                          control={control}
+                          render={({ field: { onChange, value } }) => {
+                            return (
+                              <Select
+                                size="small"
+                                value={value.value}
+                                onValueChange={(value) => onChange({ label: value, value })}
+                              >
+                                <Select.Trigger>
+                                  <Select.Value placeholder="Select an event type" />
+                                </Select.Trigger>
+                                <Select.Content style={{ zIndex: 100 }}>
+                                  {options.map((group) => (
+                                    <Select.Group key={group.label}>
+                                      <Select.Label>{group.label}</Select.Label>
+                                      {group.options.map((option) => (
+                                        <Select.Item key={option.value} value={option.value}>
+                                          {option.label}
+                                        </Select.Item>
+                                      ))}
+                                    </Select.Group>
+                                  ))}
+                                </Select.Content>
+                              </Select>
+                            );
+                          }}
+                        />
+                      </div>
+
+                      <div className="col-span-1">
+                        <Input
+                          placeholder="Target URL"
+                          type="url"
+                          required
+                          {...register('target_url', {
+                            required: 'Please enter the target url.',
+                            pattern: {
+                              value:
+                                /^https?:\/\/(?:localhost|([a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}))(?::(\d+))?(\/[\w .-]*)*\/?(\?[=&\w.-]*)?$/,
+
+                              message: 'Please enter a valid URL.',
+                            },
+                          })}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="w-[100px] pb-3">
+                      <div className="flex items-center justify-between">
+                        <h3 className="inter-base-semibold mb-2xsmall">Active</h3>
+                        <Controller
+                          control={control}
+                          name={'active'}
+                          render={({ field: { value, onChange } }) => {
+                            return <Switch checked={value} onCheckedChange={onChange} />;
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Modal.Content>
+              <Modal.Footer>
+                <div className="flex w-full items-center justify-end gap-2">
+                  <Button variant="secondary" size="small" type="button" onClick={onClose}>
+                    Cancel
+                  </Button>
+
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    type="button"
+                    onClick={() => setTestModalState(true)}
+                    disabled={!formIsValid}
+                  >
+                    Test
+                  </Button>
+
+                  <Button variant="primary" size="small" disabled={!formIsValid}>
+                    {webhook ? 'Save and Close' : 'Create Webhook'}
+                  </Button>
+                </div>
+              </Modal.Footer>
+            </form>
+          </FormProvider>
+        </Modal.Body>
+      </Modal>
+      {openTestModal ? (
+        <WebhookTestModal
+          event_type={form.getValues('event_type').value}
+          target_url={form.getValues('target_url')}
+          onClose={closeTestModal}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/modals/webhook-test-modal.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/modals/webhook-test-modal.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import Modal from '../components/molecules/Modal';
+import { Button, toast } from '@medusajs/ui';
+import { JSONTree } from 'react-json-tree';
+import { useAdminTestWebhook } from '../hooks/webhooks/mutations';
+import { getErrorMessage } from '../utils/error-messages';
+import Spinner from '../components/atoms/Spinner';
+
+type WebhookTestModalProps = {
+  event_type: string;
+  target_url: string;
+  onClose: () => void;
+};
+
+export const WebhookTestModal: React.FC<WebhookTestModalProps> = ({ event_type, target_url, onClose }) => {
+  const testWebhook = useAdminTestWebhook();
+  const [testResponse, setTestResponse] = useState<any | null>(null);
+
+  const pingWebhook = async () => {
+    try {
+      const res = await testWebhook.mutateAsync({
+        event_type,
+        target_url,
+      });
+
+      setTestResponse(res.response);
+    } catch (error) {
+      console.error(error);
+
+      toast.error('Error', {
+        description: getErrorMessage(error),
+      });
+
+      onClose();
+    }
+  };
+
+  React.useEffect(() => {
+    pingWebhook();
+  }, []);
+
+  return (
+    <Modal handleClose={onClose}>
+      <Modal.Body>
+        <Modal.Header handleClose={onClose}>
+          <div>
+            <h1 className="inter-xlarge-semibold mb-2xsmall">Test Webhook</h1>
+          </div>
+        </Modal.Header>
+
+        <Modal.Content>
+          <div className="min-h-[400px]">
+            <h3 className="inter-base-semibold pb-5">
+              Testing webhook: {event_type} {'->'} {target_url}
+            </h3>
+
+            <div>
+              <JSONTree
+                data={testResponse}
+                theme={{
+                  base00: '#F9FAFB',
+                  base08: '#e53935',
+                  base09: '#fb8c00',
+                  base0B: '#0D9488',
+                  base0D: '#4F46E5',
+                  extend: {
+                    background: '#F9FAFB',
+                  },
+                }}
+              />
+              {!testResponse ? <Spinner size="xlarge" variant="secondary" /> : null}
+            </div>
+          </div>
+        </Modal.Content>
+        <Modal.Footer>
+          <div className="flex w-full items-center justify-end gap-2">
+            <Button variant="primary" size="small" onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal.Body>
+    </Modal>
+  );
+};

--- a/v1/packages/medusa-plugin-webhooks/src/admin/settings/webhooks/page.tsx
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/settings/webhooks/page.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { type SettingConfig, type SettingProps } from "@medusajs/admin";
+import { ArrowLeft } from "@medusajs/icons";
+import { Container, Toaster } from "@medusajs/ui";
+import { WebhooksTable } from "../../components/molecules/WebhooksTable";
+import { Webhook } from "../../../models";
+import { Plus } from "@medusajs/icons";
+import Actionables from "../../components/molecules/Actionables";
+import { WebhookModal } from "../../modals/webhook-modal";
+import { WebhookDeleteModal } from "../../modals/webhook-delete-modal";
+
+const Webhooks = ({ notify }: SettingProps) => {
+  const [showNewWebhook, setShowNewWebhook] = useState(false);
+  const [showEditWebhook, setEditWebhook] = useState<Webhook | null>(null);
+  const [showDeleteWebhook, setDeleteWebhook] = useState<Webhook | null>(null);
+  const [refreshTable, setRefreshTable] = useState<() => void | null>(null);
+
+  const actionables = [
+    {
+      label: "Add New Event",
+      onClick: () => setShowNewWebhook(true),
+      icon: (
+        <span className="text-grey-90">
+          <Plus />
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Toaster />
+      <section className="flex flex-row justify-between items-center align-middle mb-6">
+        <button className={"px-small py-small"}>
+          <div className="flex gap-x-xsmall inter-grey-40 inter-small-semibold items-center text-grey-50">
+            <ArrowLeft />
+            <span className="ml-1">Go back</span>
+          </div>
+        </button>
+        <Actionables actions={actionables} />
+      </section>
+
+      <Container>
+        <div className="mb-3">
+          <h1 className="inter-xlarge-semibold text-grey-90">Webhooks</h1>
+          <p>
+            Manage the webhooks that you are sending to third party services.
+          </p>
+        </div>
+        <WebhooksTable
+          editWebhookModal={setEditWebhook}
+          deleteWebooksModal={setDeleteWebhook}
+          setRefreshTable={setRefreshTable}
+        />
+
+        {(showNewWebhook || showEditWebhook) && (
+          <WebhookModal
+            onClose={() => {
+              setShowNewWebhook(false);
+              setEditWebhook(null);
+              refreshTable?.();
+            }}
+            webhook={showEditWebhook}
+          />
+        )}
+
+        {showDeleteWebhook && (
+          <WebhookDeleteModal
+            onClose={() => {
+              setDeleteWebhook(null);
+              refreshTable?.();
+            }}
+            webhook={showDeleteWebhook}
+          />
+        )}
+      </Container>
+    </>
+  );
+};
+
+export const config: SettingConfig = {
+  card: {
+    label: "Webooks",
+    description: "Manage your webhooks",
+  },
+};
+
+export default Webhooks;

--- a/v1/packages/medusa-plugin-webhooks/src/admin/utils/error-messages.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/admin/utils/error-messages.ts
@@ -1,0 +1,10 @@
+export const getErrorMessage = (error: any) => {
+  let msg = error?.response?.data?.message ?? error?.body?.message;
+  if (msg[0].message) {
+    msg = msg[0].message;
+  }
+  if (!msg) {
+    msg = 'Something went wrong, Please try again.';
+  }
+  return msg;
+};

--- a/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/[id]/route.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/[id]/route.ts
@@ -1,0 +1,21 @@
+import { validator, type MedusaRequest, type MedusaResponse } from '@medusajs/medusa';
+import { EditWebhookReq } from '../../../validators';
+import { WebhookService } from '../../../../services';
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const validated = await validator(EditWebhookReq, req.body);
+
+  const webhookService = req.scope.resolve<WebhookService>('webhookService');
+
+  const subscription = await webhookService.updateWebhookSubscription(req.params.id, validated);
+
+  res.status(200).json({ subscription });
+};
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const webhookService = req.scope.resolve<WebhookService>('webhookService');
+
+  const subscription = await webhookService.deleteWebhookSubscription(req.params.id);
+
+  res.status(200).json({ subscription });
+}

--- a/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/events/route.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/events/route.ts
@@ -1,0 +1,50 @@
+import {
+  CustomerService,
+  OrderService,
+  ProductService,
+  type MedusaRequest,
+  type MedusaResponse,
+} from '@medusajs/medusa';
+import { WebhookService } from '../../../../services';
+
+interface EventOption {
+  label: string;
+  value: string;
+}
+
+export interface EventOptions {
+  label: string;
+  options: EventOption[];
+}
+
+const mapServiceToEvents = (service: typeof OrderService | typeof ProductService | typeof CustomerService) => {
+  return Object.values(service.Events).map((event) => ({ label: event, value: event })) as EventOption[];
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const webhookService = req.scope.resolve<WebhookService>('webhookService');
+
+  const options: EventOptions[] = [
+    {
+      label: 'Orders',
+      options: mapServiceToEvents(OrderService),
+    },
+    {
+      label: 'Products',
+      options: mapServiceToEvents(ProductService),
+    },
+    {
+      label: 'Customers',
+      options: mapServiceToEvents(CustomerService),
+    },
+  ];
+
+  if (webhookService.customSubscriptions.length > 0) {
+    options.unshift({
+      label: 'Custom',
+      options: webhookService.customSubscriptions.map((subscription) => ({ label: subscription, value: subscription })),
+    });
+  }
+
+  res.status(200).json({ options });
+};

--- a/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/route.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/route.ts
@@ -1,0 +1,29 @@
+import {
+  FindPaginationParams,
+  validator,
+  type MedusaRequest,
+  type MedusaResponse,
+} from "@medusajs/medusa";
+import { WebhookService } from "../../../services";
+import { CreateWebhookReq } from "../../validators";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const validatedConfig = await validator(FindPaginationParams, req.query);
+
+  const webhookService = req.scope.resolve<WebhookService>("webhookService");
+
+  const subscriptions = await webhookService.listAndCount({}, validatedConfig);
+
+  res.status(200).json({ subscriptions });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const validated = await validator(CreateWebhookReq, req.body);
+
+  const webhookService = req.scope.resolve<WebhookService>("webhookService");
+
+  const subscription =
+    await webhookService.createWebhookSubscription(validated);
+
+  res.status(200).json({ subscription });
+};

--- a/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/test/route.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/api/admin/webhooks/test/route.ts
@@ -1,0 +1,13 @@
+import { validator, type MedusaRequest, type MedusaResponse } from '@medusajs/medusa';
+import { TestWebhookReq } from '../../../validators';
+import { WebhookService } from '../../../../services';
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const validated = await validator(TestWebhookReq, req.body);
+
+  const webhookService = req.scope.resolve<WebhookService>('webhookService');
+
+  const response = await webhookService.testWebhookSubscription(validated);
+
+  res.status(200).json({ response });
+};

--- a/v1/packages/medusa-plugin-webhooks/src/api/validators.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/api/validators.ts
@@ -1,0 +1,47 @@
+import { IsString, IsOptional, IsBoolean, IsUrl } from "class-validator"
+
+export class CreateWebhookReq {
+  @IsString()
+  event_type?: string
+
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean
+
+  @IsString()
+  target_url?: string
+}
+
+export class EditWebhookReq {
+  @IsString()
+  id: string
+
+  @IsString()
+  event_type?: string
+
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean
+
+  @IsString()
+  target_url?: string
+}
+
+export class TestWebhookReq {
+  @IsString()
+  @IsOptional()
+  id: string
+
+  @IsString()
+  event_type: string
+
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean
+
+  @IsUrl({
+    require_tld: false,
+    require_protocol: true,
+  })
+  target_url: string
+}

--- a/v1/packages/medusa-plugin-webhooks/src/index.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./models/webhook";
+export * from "./repositories";
+export * from "./services";

--- a/v1/packages/medusa-plugin-webhooks/src/migrations/1705957279005-WebhookCreate.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/migrations/1705957279005-WebhookCreate.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class WebhookCreate1705957279005 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create a the webhook table
+    await queryRunner.query(`
+            CREATE TABLE "webhook" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "target_url" varchar NOT NULL,
+                "event_type" varchar NOT NULL,
+                "active" boolean NOT NULL DEFAULT true,
+                "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), 
+                "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), 
+                "deleted_at" TIMESTAMP WITH TIME ZONE )`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the webhook table
+    await queryRunner.query(`DROP TABLE "webhook"`)
+  }
+}

--- a/v1/packages/medusa-plugin-webhooks/src/models/index.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from "./webhook";

--- a/v1/packages/medusa-plugin-webhooks/src/models/webhook.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/models/webhook.ts
@@ -1,0 +1,19 @@
+import { SoftDeletableEntity, generateEntityId } from "@medusajs/medusa"
+import { BeforeInsert, Column, Entity } from "typeorm"
+
+@Entity()
+export class Webhook extends SoftDeletableEntity {
+  @Column({ nullable: false, type: "varchar" })
+  event_type: string
+
+  @Column({ type: "boolean", nullable: false, default: true })
+  active: boolean
+
+  @Column({ nullable: false })
+  target_url: string
+
+  @BeforeInsert()
+  private beforeInsert(): void {
+    this.id = generateEntityId(this.id, "webhook")
+  }
+}

--- a/v1/packages/medusa-plugin-webhooks/src/repositories/index.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/repositories/index.ts
@@ -1,0 +1,1 @@
+export { default as WebhookRepository } from './webhook';

--- a/v1/packages/medusa-plugin-webhooks/src/repositories/webhook.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/repositories/webhook.ts
@@ -1,0 +1,5 @@
+import { Webhook } from '../models';
+import { dataSource } from '@medusajs/medusa/dist/loaders/database';
+
+const WebhookRepository = dataSource.getRepository(Webhook);
+export default WebhookRepository;

--- a/v1/packages/medusa-plugin-webhooks/src/services/index.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/services/index.ts
@@ -1,0 +1,5 @@
+export { default as WebhookService } from "./webhook"
+
+export default class DoNothingService {
+  constructor() {}
+}

--- a/v1/packages/medusa-plugin-webhooks/src/services/webhook.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/services/webhook.ts
@@ -1,0 +1,391 @@
+import {
+  CustomerService,
+  FindConfig,
+  Logger,
+  OrderService,
+  ProductService,
+  Selector,
+  TransactionBaseService,
+  buildQuery,
+} from "@medusajs/medusa";
+import { EntityManager } from "typeorm";
+import { WebhookRepository } from "../repositories";
+import { Webhook } from "../models";
+import { MedusaError } from "medusa-core-utils";
+import OrderRepository from "@medusajs/medusa/dist/repositories/order";
+import {
+  defaultAdminOrdersFields,
+  defaultAdminOrdersRelations,
+} from "@medusajs/medusa/dist/types/orders";
+import fetch from "node-fetch";
+
+type WebhookSendResponse = {
+  event_type: string;
+  target_url: string;
+  result: "success" | "error";
+  data?: any;
+  message?: string;
+  err?: any;
+};
+
+type WebhookSendResponseError = {
+  message: string;
+  cause: {
+    code: string;
+  };
+};
+
+type InjectedDependencies = {
+  logger: Logger;
+  manager: EntityManager;
+  productService: ProductService;
+  orderService: OrderService;
+  customerService: CustomerService;
+  readonly webhookRepository: typeof WebhookRepository;
+  orderRepository: typeof OrderRepository;
+};
+
+type BaseWebhook = Pick<Webhook, "target_url" | "event_type">;
+
+class WebhookService extends TransactionBaseService {
+  private readonly logger_: Logger;
+
+  readonly productService_: ProductService;
+  readonly orderService_: OrderService;
+  readonly customerService_: CustomerService;
+
+  private readonly webhookRepository_: typeof WebhookRepository;
+  private readonly orderRepository_: typeof OrderRepository;
+
+  public readonly customSubscriptions: string[] = [];
+
+  constructor(
+    container: InjectedDependencies,
+    { customSubscriptions = [] }: { customSubscriptions: string[] }
+  ) {
+    super(container);
+    this.logger_ = container.logger;
+
+    this.productService_ = container.productService;
+    this.orderService_ = container.orderService;
+    this.customerService_ = container.customerService;
+    this.webhookRepository_ = container.webhookRepository;
+    this.orderRepository_ = container.orderRepository;
+    this.customSubscriptions = customSubscriptions;
+  }
+
+  private onSendError(
+    err: WebhookSendResponseError,
+    subscription: BaseWebhook,
+    payload: any
+  ): WebhookSendResponse {
+    this.logger_.error("Error sending webhook", {
+      subscription,
+      payload,
+      err,
+    });
+
+    return {
+      event_type: subscription.event_type,
+      target_url: subscription.target_url,
+      result: "error",
+      message: err?.message ?? err?.cause?.code ?? "Unknown error",
+      err: err?.cause ?? err,
+    };
+  }
+
+  async listAndCount(
+    selector: Selector<Webhook>,
+    config: any
+  ): Promise<[Webhook[], number]> {
+    const repo = this.activeManager_.withRepository(this.webhookRepository_);
+
+    const query = buildQuery(selector, {
+      skip: config.offset,
+      take: config.limit,
+    });
+
+    return await repo.findAndCount(query);
+  }
+
+  public async list(
+    selector: Selector<Webhook>,
+    config?: FindConfig<Webhook>
+  ): Promise<Webhook[]> {
+    const repo = this.activeManager_.withRepository(this.webhookRepository_);
+    const query = buildQuery(selector, config);
+
+    const subscriptions = await repo.find(query);
+
+    return subscriptions;
+  }
+
+  public async send(
+    subscription: BaseWebhook,
+    payload: any
+  ): Promise<WebhookSendResponse> {
+    const { event_type, target_url } = subscription;
+
+    try {
+      const response = await fetch(target_url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const contentType = response.headers.get("content-type");
+      const data = contentType?.includes("json")
+        ? await response.json()
+        : await response.text();
+
+      return {
+        event_type,
+        target_url,
+        result: "success",
+        data,
+      };
+    } catch (err) {
+      return this.onSendError(err, subscription, payload);
+    }
+  }
+
+  public async sendWebhooksEvents(webhooks: Webhook[], payload: any) {
+    const results = (await Promise.allSettled(
+      webhooks.map((webhook) => this.send(webhook, payload))
+    )) as PromiseFulfilledResult<WebhookSendResponse>[];
+
+    results.forEach((result) => {
+      const resultMessage =
+        result.value?.result === "error" ? "failed" : "succeeded";
+
+      this.logger_.info(
+        `Webhook ${result.value?.event_type} -> ${result.value?.target_url} ${resultMessage}.`
+      );
+    });
+
+    return results;
+  }
+
+  public async createWebhookSubscription(data: Partial<Webhook>) {
+    return await this.atomicPhase_(async (transactionManager) => {
+      const webhookRepo = transactionManager.withRepository(
+        this.webhookRepository_
+      );
+
+      const subscription = webhookRepo.create(data);
+
+      await webhookRepo.save(subscription);
+
+      return subscription;
+    });
+  }
+
+  public async updateWebhookSubscription(id: string, data: any) {
+    return await this.atomicPhase_(async (transactionManager) => {
+      const webhookRepo = transactionManager.withRepository(
+        this.webhookRepository_
+      );
+
+      const existingWebhook = await webhookRepo.findOne({ where: { id } });
+
+      if (!existingWebhook) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `Webhook subscription with id: ${id} was not found.`
+        );
+      }
+
+      const updatedWebhook = webhookRepo.merge(existingWebhook, data);
+
+      return await webhookRepo.save(updatedWebhook);
+    });
+  }
+
+  public async deleteWebhookSubscription(id: string) {
+    return await this.atomicPhase_(async (transactionManager) => {
+      const webhookRepo = transactionManager.withRepository(
+        this.webhookRepository_
+      );
+
+      const subscription = await webhookRepo.findOne({ where: { id } });
+
+      if (!subscription) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `Webhook subscription with id: ${id} was not found.`
+        );
+      }
+
+      await webhookRepo.remove(subscription);
+
+      return subscription;
+    });
+  }
+
+  public async retrieveWebhooksOrderWithTotals(orderId: string) {
+    const blacklistedRelations = [
+      "claims",
+      "swaps",
+      "children",
+      "returns",
+      "payments",
+      "refunds",
+      "region",
+    ];
+
+    const order = await this.orderService_.retrieveWithTotals(orderId, {
+      relations: defaultAdminOrdersRelations,
+      select: defaultAdminOrdersFields,
+    });
+
+    const removedBlacklistedFields = Object.keys(order).reduce((acc, key) => {
+      if (blacklistedRelations.includes(key)) {
+        return acc;
+      }
+
+      return {
+        ...acc,
+        [key]: order[key],
+      };
+    }, {});
+
+    return removedBlacklistedFields;
+  }
+
+  public async testWebhookSubscription(testData?: BaseWebhook) {
+    const eventType = this.detectTypeOfEvent(testData?.event_type);
+
+    if (!eventType) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Event type ${testData?.event_type} is not supported.`
+      );
+    }
+
+    const finalTestData = (await eventType.returnFirstEntityObject(
+      testData?.event_type
+    )) ?? {
+      test: true,
+    };
+
+    const response = await this.send(testData, finalTestData);
+
+    return response;
+  }
+
+  public webhookResponse(
+    {
+      event_type,
+      payload,
+    }: {
+      event_type: string;
+      payload: any;
+    },
+    type: "product" | "order" | "customer" | "custom"
+  ) {
+    return {
+      event_type,
+      payload,
+      [`${type}Id`]: payload.id,
+    };
+  }
+
+  private allEventsForWebhookTests: () => {
+    type: "orderService" | "productService" | "customerService" | "custom";
+    eventNames: string[];
+    returnFirstEntityObject: any;
+  }[] = () => [
+    {
+      type: "orderService",
+      eventNames: Object.values(OrderService.Events),
+      returnFirstEntityObject: async (eventName) => {
+        const order = await this.orderService_.list(
+          {},
+          {
+            order: { created_at: "DESC" },
+            take: 1,
+          }
+        );
+
+        if (!order?.length) {
+          return null;
+        }
+
+        const orderWithTotals = await this.retrieveWebhooksOrderWithTotals(
+          order[0].id
+        );
+
+        return this.webhookResponse(
+          {
+            event_type: eventName,
+            payload: orderWithTotals,
+          },
+          "order"
+        );
+      },
+    },
+    {
+      type: "productService",
+      eventNames: Object.values(ProductService.Events),
+      returnFirstEntityObject: async () => {
+        const product = await this.productService_.list({}, { take: 1 });
+
+        return this.webhookResponse(
+          {
+            event_type: ProductService.Events.CREATED,
+            payload: product?.length ? product[0] : null,
+          },
+          "product"
+        );
+      },
+    },
+    {
+      type: "customerService",
+      eventNames: Object.values(CustomerService.Events),
+      returnFirstEntityObject: async () => {
+        const customer = await this.customerService_.list({}, { take: 1 });
+
+        return this.webhookResponse(
+          {
+            event_type: CustomerService.Events.CREATED,
+            payload: customer?.length ? customer[0] : null,
+          },
+          "customer"
+        );
+      },
+    },
+    {
+      type: "custom",
+      eventNames: this.customSubscriptions,
+      returnFirstEntityObject: async (eventName) => {
+        return this.webhookResponse(
+          {
+            event_type: eventName,
+            payload: {
+              test: true,
+              eventName,
+              description: "This is a test payload for the webhook",
+            },
+          },
+          "custom"
+        );
+      },
+    },
+  ];
+
+  private detectTypeOfEvent = (event: string) => {
+    const foundEvent = this.allEventsForWebhookTests().find((e) =>
+      e.eventNames.includes(event)
+    );
+
+    if (!foundEvent) {
+      return false;
+    }
+
+    return foundEvent;
+  };
+}
+
+export default WebhookService;

--- a/v1/packages/medusa-plugin-webhooks/src/subscribers/webhook.ts
+++ b/v1/packages/medusa-plugin-webhooks/src/subscribers/webhook.ts
@@ -1,0 +1,103 @@
+import {
+  CustomerService,
+  EventBusService,
+  Logger,
+  OrderService,
+  ProductService,
+  defaultAdminCustomersRelations,
+  defaultAdminProductRelations,
+} from '@medusajs/medusa';
+import { WebhookService } from '../services';
+
+interface ConstructorArgs {
+  logger: Logger;
+  eventBusService: EventBusService;
+  webhookService: WebhookService;
+  productService: ProductService;
+  customerService: CustomerService;
+}
+
+export class WebhookSubscriber {
+  private logger_: Logger;
+  private eventBusService_: EventBusService;
+  private webhookService_: WebhookService;
+  private productService_: ProductService;
+  private customerService_: CustomerService;
+
+  constructor(args: ConstructorArgs) {
+    this.logger_ = args.logger;
+    this.eventBusService_ = args.eventBusService;
+    this.webhookService_ = args.webhookService;
+    this.productService_ = args.productService;
+    this.customerService_ = args.customerService;
+
+    Object.values(OrderService.Events).forEach((event) => {
+      this.eventBusService_.subscribe(event, (payload) => this.handleOrderEvent(event, payload));
+    });
+
+    Object.values(ProductService.Events).forEach((event) => {
+      this.eventBusService_.subscribe(event, (payload) => this.handleProductEvent(event, payload));
+    });
+
+    Object.values(CustomerService.Events).forEach((event) => {
+      this.eventBusService_.subscribe(event, (payload) => this.handleCustomerEvent(event, payload));
+    });
+  }
+
+  async handleOrderEvent(event: string, payload: any) {
+    const order = await this.webhookService_.retrieveWebhooksOrderWithTotals(payload.id);
+
+    const webhooks = await this.webhookService_.list({
+      event_type: event,
+      active: true,
+    });
+
+    await this.webhookService_.sendWebhooksEvents(
+      webhooks,
+      this.webhookService_.webhookResponse({ event_type: event, payload: order }, 'order'),
+    );
+  }
+
+  async handleProductEvent(event: string, payload: any) {
+    const product =
+      payload.id && event !== ProductService.Events.DELETED
+        ? await this.productService_.retrieve(payload.id, {
+            relations: defaultAdminProductRelations,
+          })
+        : null;
+
+    const webhooks = await this.webhookService_.list({
+      event_type: event,
+      active: true,
+    });
+
+    await this.webhookService_.sendWebhooksEvents(
+      webhooks,
+      this.webhookService_.webhookResponse(
+        {
+          event_type: event,
+          payload: product,
+        },
+        'product',
+      ),
+    );
+  }
+
+  async handleCustomerEvent(event: string, payload: any) {
+    const customer = await this.customerService_.retrieve(payload.id, {
+      relations: defaultAdminCustomersRelations,
+    });
+
+    const webhooks = await this.webhookService_.list({
+      event_type: event,
+      active: true,
+    });
+
+    await this.webhookService_.sendWebhooksEvents(
+      webhooks,
+      this.webhookService_.webhookResponse({ event_type: event, payload: customer }, 'customer'),
+    );
+  }
+}
+
+export default WebhookSubscriber;

--- a/v1/packages/medusa-plugin-webhooks/tsconfig.admin.json
+++ b/v1/packages/medusa-plugin-webhooks/tsconfig.admin.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "include": ["src/admin"],
+  "exclude": ["**/*.spec.js"]
+}

--- a/v1/packages/medusa-plugin-webhooks/tsconfig.json
+++ b/v1/packages/medusa-plugin-webhooks/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "ts-node": {
+    "files": true
+  },
+  "compilerOptions": {
+    "lib": ["es5", "es6", "es2019"],
+    "module": "CommonJS",
+    "checkJs": false,
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+    "target": "es2019",
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "noEmit": false
+  },
+  "include": ["./src/**/*", "medusa-config.js"],
+  "exclude": ["dist", "node_modules", "**/*.spec.ts"]
+}

--- a/v1/packages/medusa-plugin-webhooks/tsconfig.server.json
+++ b/v1/packages/medusa-plugin-webhooks/tsconfig.server.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["src/admin", "**/*.spec.js"]
+}


### PR DESCRIPTION
Deprecated: https://www.npmjs.com/package/@lambdacurry/medusa-plugin-webhooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new guide with a deprecation notice, directing users to upgrade to the Medusa2 plugin.
  
- **New Features**
  - Launched a comprehensive webhook management solution in the admin interface.
  - Introduced interactive components for creating, editing, deleting, testing, and listing webhook subscriptions.
  - Enhanced user experience with updated modals, tables, and visual indicators for real-time feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->