### PR TITLE
Fix/multiple refunds optional void

### DIFF
--- a/plugins/braintree-payment/CHANGELOG.md
+++ b/plugins/braintree-payment/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Add `disableVoidTransactions` option: when enabled, refunds never void and only proceed for `settled`/`settling` transactions (late requirement for future partial order refunds and order edits). Unsettled refunds throw `INVALID_DATA` with “cannot be refunded right now”.
+- Move sandbox settle-before-refund from reading `process.env.TEST_FORCE_SETTLED` inside the provider to a `testForceSettled` option (wire `TEST_FORCE_SETTLED` in `medusa-config` if you still use the env var).
 
 ## 0.1.8
 

--- a/plugins/braintree-payment/CHANGELOG.md
+++ b/plugins/braintree-payment/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 0.1.9-next
+## 0.2.0-next
+
+### Fixes
+
+- Keep refund/void history on `braintreeRefunds[]` (same key as 0.1.8). Read leftover `braintreeRefund` arrays from the 0.2.0-next regression and migrate them onto `braintreeRefunds` on the next refund so both keys cannot drift.
 
 ### Improvements
 
-- Add `disableVoidTransactions` option: when enabled, refunds never void and only proceed for `settled`/`settling` transactions (late requirement for future partial order refunds and order edits). Unsettled refunds throw `INVALID_DATA` with “cannot be refunded right now”.
+- Add `disableVoidTransactions` option: when enabled, refunds never void. Only `settled`/`settling` may be refunded; `authorized`/`submitted_for_settlement` throw `INVALID_DATA` with “cannot be refunded right now”; other statuses throw `NOT_FOUND` with “cannot be refunded” (late requirement for future partial order refunds and order edits).
 - Move sandbox settle-before-refund from reading `process.env.TEST_FORCE_SETTLED` inside the provider to a `testForceSettled` option (wire `TEST_FORCE_SETTLED` in `medusa-config` if you still use the env var).
 
 ## 0.1.8

--- a/plugins/braintree-payment/CHANGELOG.md
+++ b/plugins/braintree-payment/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.9-next
+
+### Improvements
+
+- Add `disableVoidTransactions` option: when enabled, refunds never void and only proceed for `settled`/`settling` transactions (late requirement for future partial order refunds and order edits). Unsettled refunds throw `INVALID_DATA` with “cannot be refunded right now”.
+
 ## 0.1.8
 
 ### Fixes

--- a/plugins/braintree-payment/README.md
+++ b/plugins/braintree-payment/README.md
@@ -90,6 +90,7 @@ dependencies:[Modules.CACHE]
     savePaymentMethod: true, // Save payment methods for future use
     autoCapture: true,        // Automatically capture payments
     allowRefundOnRefunded: false,
+    disableVoidTransactions: false,
     logging: process.env.BRAINTREE_LOGGING === 'true', // Enable plugin debug logs
   }
 }
@@ -106,6 +107,7 @@ dependencies:[Modules.CACHE]
 - **savePaymentMethod**: Save payment methods for future use (default: `true`).
 - **autoCapture**: Automatically capture payments (default: `true`).
 - **allowRefundOnRefunded**: Allow refund attempts on already-refunded imported transactions (default: `false`).
+- **disableVoidTransactions**: When `true`, refunds never void; only `settled`/`settling` transactions may be refunded. Late requirement so future partial order refunds and order edits can be supported (void cancels the full authorization). Default: `false`. With this enabled, refunds on unsettled transactions fail with “cannot be refunded right now”.
 - **logging**: Enable verbose plugin debug logging (`true` or `false`, default: `false`). When `true`, the provider logs operation details (initiate, authorize, capture, refund, etc.) and expanded Braintree error context via Medusa's logger with a `[Braintree]` prefix. Set via `BRAINTREE_LOGGING=true` in `.env` or pass `logging: true` directly in provider options. Disable in production unless actively debugging.
 
 ### Debug logging
@@ -140,6 +142,7 @@ Earlier README examples used `logging: process.env.NODE_ENV !== 'production'` (a
 > - `autoCapture`: If set to `true`, payments are captured automatically after authorization.
 > - `savePaymentMethod`: If set to `true`, customer payment methods are saved for future use.
 > - `allowRefundOnRefunded`: If set to `true`, the imported payment provider will gracefully handle refund attempts on transactions that have already been refunded in Braintree. Instead of throwing an error, it will log a warning and record the refund locally only. This is useful when orders are imported and later refunded directly in Braintree.
+> - `disableVoidTransactions`: Late additional requirement so future partial order refunds and order edits can be supported. When `true`, the provider waits for `settled`/`settling` before refunding; otherwise refund fails with “cannot be refunded right now”. `cancelPayment` may still void.
 
 ### 3D Secure Setup
 

--- a/plugins/braintree-payment/README.md
+++ b/plugins/braintree-payment/README.md
@@ -116,7 +116,7 @@ dependencies:[Modules.CACHE]
 - **savePaymentMethod**: Save payment methods for future use (default: `true`).
 - **autoCapture**: Automatically capture payments (default: `true`).
 - **allowRefundOnRefunded**: Allow refund attempts on already-refunded imported transactions (default: `false`).
-- **disableVoidTransactions**: When `true`, refunds never void; only `settled`/`settling` transactions may be refunded. Late requirement so future partial order refunds and order edits can be supported (void cancels the full authorization). Default: `false`. With this enabled, refunds on unsettled transactions fail with “cannot be refunded right now”.
+- **disableVoidTransactions**: When `true`, refunds never void; only `settled`/`settling` transactions may be refunded. Late requirement so future partial order refunds and order edits can be supported (void cancels the full authorization). Default: `false`. With this enabled, `authorized`/`submitted_for_settlement` refunds fail with `INVALID_DATA` (“cannot be refunded right now”); other non-refundable statuses fail with `NOT_FOUND` (“cannot be refunded”).
 - **logging**: Enable verbose plugin debug logging (`true` or `false`, default: `false`). When `true`, the provider logs operation details (initiate, authorize, capture, refund, etc.) and expanded Braintree error context via Medusa's logger with a `[Braintree]` prefix. Set via `BRAINTREE_LOGGING=true` in `.env` or pass `logging: true` directly in provider options. Disable in production unless actively debugging.
 - **testForceSettled**: **Sandbox only.** When `true` **and** `environment` is `sandbox`, the refund flow settles the Braintree transaction via the sandbox testing API before attempting a refund. Use this to exercise the **refund** path (settled/settling) instead of the **void** path (authorized/submitted_for_settlement). Defaults to `false`. Ignored (with a warning) outside sandbox. Set via `TEST_FORCE_SETTLED=true` in `.env` wired to this option, or pass `testForceSettled: true` directly. Do not enable in production.
 
@@ -152,7 +152,11 @@ Earlier README examples used `logging: process.env.NODE_ENV !== 'production'` (a
 > - `autoCapture`: If set to `true`, payments are captured automatically after authorization.
 > - `savePaymentMethod`: If set to `true`, customer payment methods are saved for future use.
 > - `allowRefundOnRefunded`: If set to `true`, the imported payment provider will gracefully handle refund attempts on transactions that have already been refunded in Braintree. Instead of throwing an error, it will log a warning and record the refund locally only. This is useful when orders are imported and later refunded directly in Braintree.
-> - `disableVoidTransactions`: Late additional requirement so future partial order refunds and order edits can be supported. When `true`, the provider waits for `settled`/`settling` before refunding; otherwise refund fails with “cannot be refunded right now”. `cancelPayment` may still void.
+
+### Upgrading to 0.2.0-next
+
+> **Note:**
+> - `disableVoidTransactions`: Late additional requirement so future partial order refunds and order edits can be supported. When `true`, only `settled`/`settling` may be refunded; `authorized`/`submitted_for_settlement` fail with `INVALID_DATA` (“cannot be refunded right now”); other statuses fail with `NOT_FOUND` (“cannot be refunded”). `cancelPayment` may still void.
 
 ### 3D Secure Setup
 

--- a/plugins/braintree-payment/README.md
+++ b/plugins/braintree-payment/README.md
@@ -41,8 +41,8 @@ BRAINTREE_PRIVATE_KEY=<your_private_key>
 BRAINTREE_WEBHOOK_SECRET=<your_webhook_secret>
 BRAINTREE_ENVIRONMENT=sandbox|development|production|qa
 BRAINTREE_ENABLE_3D_SECURE=true|false
-TEST_FORCE_SETTLED=true|false
 BRAINTREE_LOGGING=true|false
+TEST_FORCE_SETTLED=true|false
 ```
 
 - `BRAINTREE_PUBLIC_KEY`: Your Braintree public key.
@@ -51,8 +51,8 @@ BRAINTREE_LOGGING=true|false
 - `BRAINTREE_WEBHOOK_SECRET`: Secret for validating Braintree webhooks.
 - `BRAINTREE_ENVIRONMENT`: One of `sandbox`, `development`, `production`, or `qa`.
 - `BRAINTREE_ENABLE_3D_SECURE`: Set to `true` to enable 3D Secure authentication, otherwise `false`.
-- `TEST_FORCE_SETTLED`: **Sandbox only.** When set to `true` **and** `BRAINTREE_ENVIRONMENT=sandbox`, the refund flow settles the Braintree transaction via the sandbox testing API before attempting a refund. Use this to exercise the **refund** path (settled/settling) instead of the **void** path (authorized/submitted_for_settlement). Defaults to `false`. Ignored (with a warning) outside sandbox. Do not enable in production.
 - `BRAINTREE_LOGGING`: Optional. Set to `true` to enable plugin debug logging. Wire this to the provider `logging` option in `medusa-config.ts` (see below). Defaults to `false`.
+- `TEST_FORCE_SETTLED`: Optional. **Sandbox only.** Wire this to the provider `testForceSettled` option in `medusa-config.ts` (see below). Defaults to `false`. Do not enable in production.
 
 ### Testing refunds in sandbox
 
@@ -61,14 +61,22 @@ In Braintree sandbox, transactions often remain in `authorized` or `submitted_fo
 - **Void path:** `authorized`, `submitted_for_settlement`
 - **Refund path:** `settled`, `settling`
 
-To test the refund path locally without waiting for settlement, set:
+To test the refund path locally without waiting for settlement, set `environment: 'sandbox'` and `testForceSettled: true` in provider options (optionally via env):
 
 ```env
 BRAINTREE_ENVIRONMENT=sandbox
 TEST_FORCE_SETTLED=true
 ```
 
-When both are set, `refundPayment` calls Braintree's sandbox `testing.settle` on the transaction, re-fetches it, then proceeds with `transaction.refund`. If `TEST_FORCE_SETTLED=true` but the provider environment is not `sandbox`, the settle step is skipped and a warning is logged.
+```javascript
+options: {
+  environment: process.env.BRAINTREE_ENVIRONMENT || 'sandbox',
+  testForceSettled: process.env.TEST_FORCE_SETTLED === 'true',
+  // ...
+}
+```
+
+When both are set, `refundPayment` calls Braintree's sandbox `testing.settle` on the transaction, re-fetches it, then proceeds with `transaction.refund`. If `testForceSettled` is `true` but the provider environment is not `sandbox`, the settle step is skipped and a warning is logged.
 
 ### Medusa Configuration
 
@@ -92,6 +100,7 @@ dependencies:[Modules.CACHE]
     allowRefundOnRefunded: false,
     disableVoidTransactions: false,
     logging: process.env.BRAINTREE_LOGGING === 'true', // Enable plugin debug logs
+    testForceSettled: process.env.TEST_FORCE_SETTLED === 'true', // Sandbox: settle before refund
   }
 }
 ```
@@ -109,6 +118,7 @@ dependencies:[Modules.CACHE]
 - **allowRefundOnRefunded**: Allow refund attempts on already-refunded imported transactions (default: `false`).
 - **disableVoidTransactions**: When `true`, refunds never void; only `settled`/`settling` transactions may be refunded. Late requirement so future partial order refunds and order edits can be supported (void cancels the full authorization). Default: `false`. With this enabled, refunds on unsettled transactions fail with “cannot be refunded right now”.
 - **logging**: Enable verbose plugin debug logging (`true` or `false`, default: `false`). When `true`, the provider logs operation details (initiate, authorize, capture, refund, etc.) and expanded Braintree error context via Medusa's logger with a `[Braintree]` prefix. Set via `BRAINTREE_LOGGING=true` in `.env` or pass `logging: true` directly in provider options. Disable in production unless actively debugging.
+- **testForceSettled**: **Sandbox only.** When `true` **and** `environment` is `sandbox`, the refund flow settles the Braintree transaction via the sandbox testing API before attempting a refund. Use this to exercise the **refund** path (settled/settling) instead of the **void** path (authorized/submitted_for_settlement). Defaults to `false`. Ignored (with a warning) outside sandbox. Set via `TEST_FORCE_SETTLED=true` in `.env` wired to this option, or pass `testForceSettled: true` directly. Do not enable in production.
 
 ### Debug logging
 

--- a/plugins/braintree-payment/package.json
+++ b/plugins/braintree-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/medusa-payment-braintree",
-  "version": "0.1.10-next",
+  "version": "0.2.0-next",
   "description": "Braintree plugin for Medusa",
   "author": "Lambda Curry (https://lambdacurry.dev)",
   "license": "MIT",

--- a/plugins/braintree-payment/package.json
+++ b/plugins/braintree-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/medusa-payment-braintree",
-  "version": "0.1.8",
+  "version": "0.1.10-next",
   "description": "Braintree plugin for Medusa",
   "author": "Lambda Curry (https://lambdacurry.dev)",
   "license": "MIT",

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-base.spec.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-base.spec.ts
@@ -75,20 +75,12 @@ const settledRefundInput = (amount: number, transactionId = 't-settled'): Refund
 });
 
 describe('BraintreeProviderService core behaviors', () => {
-  const originalTestForceSettled = process.env.TEST_FORCE_SETTLED;
-
   beforeEach(() => {
     jest.resetAllMocks();
-    delete process.env.TEST_FORCE_SETTLED;
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    if (originalTestForceSettled === undefined) {
-      delete process.env.TEST_FORCE_SETTLED;
-    } else {
-      process.env.TEST_FORCE_SETTLED = originalTestForceSettled;
-    }
   });
 
   it('returns cached client token when available', async () => {
@@ -538,9 +530,8 @@ describe('BraintreeProviderService core behaviors', () => {
     });
   });
 
-  it('refundPayment settles then refunds when TEST_FORCE_SETTLED is enabled in sandbox', async () => {
-    process.env.TEST_FORCE_SETTLED = 'true';
-    const { service, gateway } = buildService({ environment: 'sandbox' });
+  it('refundPayment settles then refunds when testForceSettled is enabled in sandbox', async () => {
+    const { service, gateway } = buildService({ environment: 'sandbox', testForceSettled: true });
 
     gateway.transaction.find
       .mockResolvedValueOnce({ id: 't-force', status: 'authorized' })
@@ -561,9 +552,8 @@ describe('BraintreeProviderService core behaviors', () => {
     expect(forceEntry?.transaction?.id).toBe('r-force');
   });
 
-  it('refundPayment ignores TEST_FORCE_SETTLED outside sandbox and voids authorized transactions', async () => {
-    process.env.TEST_FORCE_SETTLED = 'true';
-    const { service, gateway, logger } = buildService({ environment: 'production' });
+  it('refundPayment ignores testForceSettled outside sandbox and voids authorized transactions', async () => {
+    const { service, gateway, logger } = buildService({ environment: 'production', testForceSettled: true });
 
     gateway.transaction.find
       .mockResolvedValueOnce({ id: 't-prod', status: 'authorized' })
@@ -576,7 +566,7 @@ describe('BraintreeProviderService core behaviors', () => {
     expect(gateway.transaction.void).toHaveBeenCalledWith('t-prod');
     expect(gateway.transaction.refund).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
-      '[Braintree refund] TEST_FORCE_SETTLED ignored — only supported when environment is sandbox',
+      '[Braintree refund] testForceSettled ignored — only supported when environment is sandbox',
     );
     const prodEntry = lastRefundEntry(result.data);
     expect(prodEntry?.type).toBe('voided');

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-base.spec.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-base.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { MedusaError } from '@medusajs/framework/utils';
+import { MedusaError, PaymentActions } from '@medusajs/framework/utils';
 import type { RefundPaymentInput } from '@medusajs/types';
 import BraintreeProviderService from '../../services/braintree-provider';
 import { BraintreeConstructorArgs, BraintreePaymentSessionData } from '../braintree-base';
@@ -11,11 +11,12 @@ type RefundHistoryEntry = {
 };
 
 type RefundResultData = {
-  braintreeRefund?: RefundHistoryEntry[];
+  braintreeRefund?: RefundHistoryEntry[] | Record<string, unknown>;
+  braintreeRefunds?: RefundHistoryEntry[];
 };
 
 const lastRefundEntry = (data: unknown): RefundHistoryEntry | undefined => {
-  const history = (data as RefundResultData)?.braintreeRefund;
+  const history = (data as RefundResultData)?.braintreeRefunds;
   return history?.[history.length - 1];
 };
 
@@ -266,7 +267,41 @@ describe('BraintreeProviderService core behaviors', () => {
     expect(lastRefundEntry(result.data)?.type).toBe('refund');
   });
 
-  it('refundPayment appends to existing braintreeRefund history', async () => {
+  it('refundPayment appends to existing braintreeRefunds history', async () => {
+    const { service, gateway } = buildService();
+    const priorEntry = {
+      type: 'refund' as const,
+      transaction: { id: 'r-prior', status: 'submitted_for_settlement' },
+    };
+
+    const input: RefundPaymentInput = {
+      amount: 3,
+      data: {
+        client_token: 'ct',
+        amount: 1000,
+        currency_code: 'USD',
+        braintreeTransaction: { id: 't1' },
+        braintreeRefunds: [priorEntry],
+      },
+    };
+
+    gateway.transaction.find.mockResolvedValueOnce({ id: 't1', status: 'settled' });
+    gateway.transaction.refund.mockResolvedValueOnce({
+      success: true,
+      transaction: { id: 'r-new', status: 'submitted_for_settlement' },
+    });
+
+    const result = await service.refundPayment(input);
+    const history = (result.data as RefundResultData)?.braintreeRefunds;
+
+    expect(history).toHaveLength(2);
+    expect(history?.[0]).toMatchObject(priorEntry);
+    expect(history?.[1]?.type).toBe('refund');
+    expect(history?.[1]?.transaction?.id).toBe('r-new');
+    expect((result.data as RefundResultData)?.braintreeRefund).toBeUndefined();
+  });
+
+  it('refundPayment migrates leftover braintreeRefund array onto braintreeRefunds', async () => {
     const { service, gateway } = buildService();
     const priorEntry = {
       type: 'refund' as const,
@@ -291,12 +326,51 @@ describe('BraintreeProviderService core behaviors', () => {
     });
 
     const result = await service.refundPayment(input);
-    const history = (result.data as RefundResultData)?.braintreeRefund;
+    const history = (result.data as RefundResultData)?.braintreeRefunds;
 
     expect(history).toHaveLength(2);
     expect(history?.[0]).toMatchObject(priorEntry);
     expect(history?.[1]?.type).toBe('refund');
     expect(history?.[1]?.transaction?.id).toBe('r-new');
+    expect((result.data as RefundResultData)?.braintreeRefund).toBeUndefined();
+  });
+
+  it('refundPayment prefers braintreeRefunds when both history keys are present', async () => {
+    const { service, gateway } = buildService();
+    const pluralEntry = {
+      type: 'refund' as const,
+      transaction: { id: 'r-plural', status: 'submitted_for_settlement' },
+    };
+    const singularEntry = {
+      type: 'refund' as const,
+      transaction: { id: 'r-singular', status: 'submitted_for_settlement' },
+    };
+
+    const input: RefundPaymentInput = {
+      amount: 3,
+      data: {
+        client_token: 'ct',
+        amount: 1000,
+        currency_code: 'USD',
+        braintreeTransaction: { id: 't1' },
+        braintreeRefunds: [pluralEntry],
+        braintreeRefund: [singularEntry],
+      },
+    };
+
+    gateway.transaction.find.mockResolvedValueOnce({ id: 't1', status: 'settled' });
+    gateway.transaction.refund.mockResolvedValueOnce({
+      success: true,
+      transaction: { id: 'r-new', status: 'submitted_for_settlement' },
+    });
+
+    const result = await service.refundPayment(input);
+    const history = (result.data as RefundResultData)?.braintreeRefunds;
+
+    expect(history).toHaveLength(2);
+    expect(history?.[0]).toMatchObject(pluralEntry);
+    expect(history?.[1]?.transaction?.id).toBe('r-new');
+    expect((result.data as RefundResultData)?.braintreeRefund).toBeUndefined();
   });
 
   it('refundPayment voids when transaction is submitted_for_settlement', async () => {
@@ -592,11 +666,12 @@ describe('BraintreeProviderService core behaviors', () => {
     gateway.transaction.find.mockResolvedValueOnce({ id: 't1', status: 'voided' });
 
     const result = await service.refundPayment(input);
-    const history = (result.data as RefundResultData)?.braintreeRefund;
+    const history = (result.data as RefundResultData)?.braintreeRefunds;
 
     expect(Array.isArray(history)).toBe(true);
     expect(history).toHaveLength(1);
     expect(history?.[0]?.type).toBe('voided');
+    expect((result.data as RefundResultData)?.braintreeRefund).toBeUndefined();
   });
 
   it('getPaymentStatus maps provider status correctly', async () => {
@@ -622,7 +697,7 @@ describe('BraintreeProviderService core behaviors', () => {
     });
 
     const result = await service.getWebhookActionAndData({ data: payloadStr } as any);
-    expect(result.action).toBe('captured');
+    expect(result.action).toBe(PaymentActions.SUCCESSFUL);
     expect((result as any).data.session_id).toBe('sess_123');
   });
 
@@ -641,7 +716,7 @@ describe('BraintreeProviderService core behaviors', () => {
       data: 'bt_signature=s&bt_payload=p',
     } as any);
 
-    expect(result.action).toBe('captured');
+    expect(result.action).toBe(PaymentActions.SUCCESSFUL);
     expect((result as any).data.session_id).toBe('');
   });
 
@@ -727,15 +802,15 @@ describe('BraintreeProviderService core behaviors', () => {
     );
   });
 
-  it('getWebhookActionAndData propagates webhook parse failures', async () => {
-    const { service, gateway } = buildService();
+  it('getWebhookActionAndData returns NOT_SUPPORTED for webhook parse failures', async () => {
+    const { service, gateway, logger } = buildService();
     gateway.webhookNotification.parse.mockRejectedValueOnce(new Error('invalid signature'));
 
-    await expect(
-      service.getWebhookActionAndData({ data: 'bt_signature=bad&bt_payload=x' } as any),
-    ).rejects.toMatchObject({
-      type: MedusaError.Types.INVALID_DATA,
-      message: expect.stringContaining('validate Braintree webhook'),
-    });
+    const result = await service.getWebhookActionAndData({
+      data: 'bt_signature=bad&bt_payload=x',
+    } as any);
+
+    expect(result.action).toBe(PaymentActions.NOT_SUPPORTED);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('webhook validation failed'));
   });
 });

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-base.spec.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-base.spec.ts
@@ -233,6 +233,47 @@ describe('BraintreeProviderService core behaviors', () => {
     expect(entry?.transaction?.id).toBe('t1');
   });
 
+  it('refundPayment throws when disableVoidTransactions and status is authorized', async () => {
+    const { service, gateway } = buildService({ disableVoidTransactions: true });
+
+    const input: RefundPaymentInput = {
+      amount: 5,
+      data: {
+        client_token: 'ct',
+        amount: 1000,
+        currency_code: 'USD',
+        braintreeTransaction: { id: 't1' },
+      },
+    };
+
+    gateway.transaction.find.mockResolvedValueOnce({ id: 't1', status: 'authorized' });
+
+    await expect(service.refundPayment(input)).rejects.toMatchObject({
+      type: MedusaError.Types.INVALID_DATA,
+      message: 'Braintree transaction with ID t1 cannot be refunded right now',
+    });
+    expect(gateway.transaction.void).not.toHaveBeenCalled();
+    expect(gateway.transaction.refund).not.toHaveBeenCalled();
+  });
+
+  it('refundPayment refunds settled transactions when disableVoidTransactions is enabled', async () => {
+    const { service, gateway } = buildService({ disableVoidTransactions: true });
+
+    gateway.transaction.find
+      .mockResolvedValueOnce({ id: 't-settled', status: 'settled' })
+      .mockResolvedValueOnce({ id: 't-settled', status: 'settled' });
+    gateway.transaction.refund.mockResolvedValueOnce({
+      success: true,
+      transaction: { id: 'r-settled', status: 'submitted_for_settlement' },
+    });
+
+    const result = await service.refundPayment(settledRefundInput(10));
+
+    expect(gateway.transaction.void).not.toHaveBeenCalled();
+    expect(gateway.transaction.refund).toHaveBeenCalledWith('t-settled', '10.00');
+    expect(lastRefundEntry(result.data)?.type).toBe('refund');
+  });
+
   it('refundPayment appends to existing braintreeRefund history', async () => {
     const { service, gateway } = buildService();
     const priorEntry = {

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-import.spec.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/__tests__/braintree-import.spec.ts
@@ -3,7 +3,7 @@ import { MedusaError } from '@medusajs/framework/utils';
 import BraintreeImportService from '../../services/braintree-import';
 import { BraintreeConstructorArgs } from '../braintree-base';
 
-const buildService = () => {
+const buildService = (overrideOptions?: Record<string, unknown>) => {
   const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any;
   const cache = { get: jest.fn(), set: jest.fn() } as any;
 
@@ -18,6 +18,7 @@ const buildService = () => {
     savePaymentMethod: false,
     webhookSecret: 'whsec',
     autoCapture: true,
+    ...overrideOptions,
   } as any;
 
   const service = new BraintreeImportService(container, options);
@@ -33,7 +34,7 @@ const buildService = () => {
 
   (service as any).gateway = gateway;
 
-  return { service, gateway };
+  return { service, gateway, logger };
 };
 
 describe('BraintreeImportService', () => {
@@ -79,6 +80,19 @@ describe('BraintreeImportService', () => {
     const res = await service.refundPayment({ amount: 10, data: session } as any);
     expect(gateway.transaction.void).toHaveBeenCalledWith('t2');
     expect((res.data as any).refundedTotal).toBe(10);
+  });
+
+  it('throws when disableVoidTransactions and status is authorized', async () => {
+    const { service, gateway } = buildService({ disableVoidTransactions: true });
+    const session = { transactionId: 't2', importedAsRefunded: false, refundedTotal: 0, status: 'captured' } as any;
+    gateway.transaction.find.mockResolvedValueOnce({ id: 't2', status: 'authorized' });
+
+    await expect(service.refundPayment({ amount: 10, data: session } as any)).rejects.toMatchObject({
+      type: MedusaError.Types.INVALID_DATA,
+      message: 'Braintree transaction with ID t2 cannot be refunded right now',
+    });
+    expect(gateway.transaction.void).not.toHaveBeenCalled();
+    expect(gateway.transaction.refund).not.toHaveBeenCalled();
   });
 
   it('performs real refund for settled/settling when not imported-refunded', async () => {

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
@@ -527,9 +527,17 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
     options.savePaymentMethod = options.savePaymentMethod ?? false;
     options.autoCapture = options.autoCapture ?? false;
     options.allowRefundOnRefunded = options.allowRefundOnRefunded ?? false;
+    options.disableVoidTransactions = options.disableVoidTransactions ?? false;
     options.logging = options.logging ?? false;
 
-    const booleanFields = ['enable3DSecure', 'savePaymentMethod', 'autoCapture', 'allowRefundOnRefunded', 'logging'];
+    const booleanFields = [
+      'enable3DSecure',
+      'savePaymentMethod',
+      'autoCapture',
+      'allowRefundOnRefunded',
+      'disableVoidTransactions',
+      'logging',
+    ];
     for (const field of booleanFields) {
       if (isDefined(options[field as keyof BraintreeOptions]) && typeof options[field as keyof BraintreeOptions] !== 'boolean') {
         throw new MedusaError(
@@ -1186,12 +1194,22 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
   /**
    * Chooses void vs refund based on transaction status (after optional test settle).
    * @param transaction - Live Braintree transaction
+   * @throws {MedusaError} `INVALID_DATA` when void is disabled and status is voidable
    * @throws {MedusaError} `NOT_FOUND` when status is neither voidable nor refundable
    */
   private async resolveRefundAction(transaction: Transaction): Promise<RefundAction> {
     const resolved = await this.applyTestForceSettled(transaction);
 
     if (isVoidableRefundStatus(resolved.status)) {
+      if (this.options.disableVoidTransactions) {
+        this.logger.error(
+          `Braintree transaction with ID ${resolved.id} cannot be refunded right now because it's in status ${resolved.status}`,
+        );
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Braintree transaction with ID ${resolved.id} cannot be refunded right now`,
+        );
+      }
       return { kind: 'voided', transaction: resolved };
     }
 

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
@@ -153,7 +153,7 @@ const isVoidableRefundStatus = (status: TransactionStatus): boolean =>
 const isSettledRefundStatus = (status: TransactionStatus): boolean =>
   (SETTLED_REFUND_STATUSES as readonly string[]).includes(status);
 
-/** One entry appended to session `data.braintreeRefund` after a void or refund. */
+/** One entry appended to session `data.braintreeRefunds` after a void or refund. */
 type BraintreeRefundHistoryEntry = {
   type: 'voided' | 'refund';
   transaction: Transaction;
@@ -1118,9 +1118,36 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
   }
 
   /**
-   * Builds refund output `data`, appending one entry to `braintreeRefund` history.
-   * Legacy non-array `braintreeRefund` values are ignored so spreads stay safe.
-   * @param input - Original refund input (prior history read from `data.braintreeRefund`)
+   * Reads refund/void history from session data.
+   * Prefers `braintreeRefunds` (0.1.8+). Falls back to an array on `braintreeRefund`
+   * (0.2.0-next regression). Non-array values on either key are discarded.
+   * @param data - Payment session `data` bag
+   */
+  private readRefundHistory(data: Record<string, unknown> | undefined): BraintreeRefundHistoryEntry[] {
+    const fromPlural = data?.braintreeRefunds;
+    if (Array.isArray(fromPlural)) {
+      return fromPlural as BraintreeRefundHistoryEntry[];
+    }
+    if (fromPlural !== undefined) {
+      this.logger.warn('[Braintree] Discarding legacy non-array braintreeRefunds session data');
+    }
+
+    const fromSingular = data?.braintreeRefund;
+    if (Array.isArray(fromSingular)) {
+      return fromSingular as BraintreeRefundHistoryEntry[];
+    }
+    if (fromSingular !== undefined) {
+      this.logger.warn('[Braintree] Discarding legacy non-array braintreeRefund session data');
+    }
+
+    return [];
+  }
+
+  /**
+   * Builds refund output `data`, appending one entry to `braintreeRefunds` history.
+   * Reads prior history from `braintreeRefunds` (preferred) or leftover `braintreeRefund`.
+   * Writes only `braintreeRefunds` so the two keys cannot drift.
+   * @param input - Original refund input (prior history read from session `data`)
    * @param transaction - Pre-refund Braintree transaction retained on session data
    * @param entry - New void/refund history entry
    */
@@ -1129,16 +1156,15 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
     transaction: Transaction,
     entry: BraintreeRefundHistoryEntry,
   ): RefundPaymentOutput {
-    const stored = input.data?.braintreeRefund;
-    const prior: BraintreeRefundHistoryEntry[] = Array.isArray(stored)
-      ? (stored as BraintreeRefundHistoryEntry[])
-      : [];
+    const prior = this.readRefundHistory(input.data);
+    const data = { ...(input.data ?? {}) };
+    delete data.braintreeRefund;
 
     return {
       data: {
-        ...input.data,
+        ...data,
         transaction,
-        braintreeRefund: [...prior, entry],
+        braintreeRefunds: [...prior, entry],
       },
     };
   }
@@ -1203,7 +1229,7 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
     const resolved = await this.applyTestForceSettled(transaction);
 
     if (isVoidableRefundStatus(resolved.status)) {
-      if (this.options.disableVoidTransactions) {
+      if (this.options_.disableVoidTransactions) {
         this.logger.error(
           `Braintree transaction with ID ${resolved.id} cannot be refunded right now because it's in status ${resolved.status}`,
         );
@@ -1273,7 +1299,7 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
 
   /**
    * Medusa refund hook: voids or refunds based on transaction status and
-   * appends history under `data.braintreeRefund`.
+   * appends history under `data.braintreeRefunds`.
    * @param input - Amount + session transaction
    */
   async refundPayment(input: RefundPaymentInput): Promise<RefundPaymentOutput> {
@@ -1427,7 +1453,7 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
    * Parses a Braintree webhook notification from form-encoded signature + payload.
    * @param webhookData - Provider webhook payload from Medusa
    * @returns Parsed notification, or `null` when parse succeeds with an empty body
-   * @throws {MedusaError} When signature/payload validation fails (does not swallow)
+   *   or when signature/payload validation fails (logged; avoids Braintree retries)
    */
   private async parseWebhookNotification(
     webhookData: ProviderWebhookPayload['payload'],
@@ -1444,10 +1470,9 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
     } catch (error) {
       this.logErrorDetail('webhook validation', error, { hasPayload: !!webhookData?.data });
       this.logger.error(`Braintree webhook validation failed : ${error}`);
-      if (MedusaError.isMedusaError(error)) throw error;
-      throw buildBraintreeError(error, 'validate Braintree webhook', this.logger, {
-        hasPayload: !!webhookData?.data,
-      });
+      // Permanently invalid signatures/payloads cannot succeed on retry; return null so
+      // getWebhookActionAndData maps to NOT_SUPPORTED (Medusa 2xx) instead of throwing.
+      return null;
     }
   }
 
@@ -1469,10 +1494,9 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
 
   /**
    * Medusa webhook hook: parses the notification and returns action + session_id/amount.
-   * Empty/null notification → `NOT_SUPPORTED`. Parse/signature failures propagate as errors.
+   * Empty/null notification or permanent parse/signature failures → `NOT_SUPPORTED`.
    * Missing custom field session id → empty string.
    * @param webhookData - Raw provider webhook payload
-   * @throws {MedusaError} When webhook validation fails
    */
   async getWebhookActionAndData(webhookData: ProviderWebhookPayload['payload']): Promise<WebhookActionResult> {
     this.logDebug('getWebhookActionAndData', { hasData: !!webhookData?.data });

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
@@ -402,11 +402,11 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
   }
 
   /**
-   * Whether sandbox test settlement is enabled (`TEST_FORCE_SETTLED=true` and env is sandbox).
+   * Whether sandbox test settlement is enabled (`testForceSettled` option and env is sandbox).
    */
   private isTestForceSettledEnabled(): boolean {
     return (
-      process.env.TEST_FORCE_SETTLED === 'true' && this.options_.environment.toLowerCase() === 'sandbox'
+      !!this.options_.testForceSettled && this.options_.environment.toLowerCase() === 'sandbox'
     );
   }
 
@@ -529,6 +529,7 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
     options.allowRefundOnRefunded = options.allowRefundOnRefunded ?? false;
     options.disableVoidTransactions = options.disableVoidTransactions ?? false;
     options.logging = options.logging ?? false;
+    options.testForceSettled = options.testForceSettled ?? false;
 
     const booleanFields = [
       'enable3DSecure',
@@ -537,6 +538,7 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
       'allowRefundOnRefunded',
       'disableVoidTransactions',
       'logging',
+      'testForceSettled',
     ];
     for (const field of booleanFields) {
       if (isDefined(options[field as keyof BraintreeOptions]) && typeof options[field as keyof BraintreeOptions] !== 'boolean') {
@@ -1174,15 +1176,15 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
 
   /**
    * Sandbox-only: force settle so refund paths can be exercised in tests.
-   * No-ops unless `TEST_FORCE_SETTLED=true` and environment is sandbox.
+   * No-ops unless `testForceSettled` is true and environment is sandbox.
    * @param transaction - Transaction to optionally settle
    */
   private async applyTestForceSettled(transaction: Transaction): Promise<Transaction> {
-    if (process.env.TEST_FORCE_SETTLED !== 'true') return transaction;
+    if (!this.options_.testForceSettled) return transaction;
 
     if (!this.isTestForceSettledEnabled()) {
       this.logger.warn(
-        '[Braintree refund] TEST_FORCE_SETTLED ignored — only supported when environment is sandbox',
+        '[Braintree refund] testForceSettled ignored — only supported when environment is sandbox',
       );
       return transaction;
     }

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-import.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-import.ts
@@ -285,6 +285,16 @@ class BraintreeImport extends AbstractPaymentProvider<BraintreeOptions> {
     const shouldVoid = ['submitted_for_settlement', 'authorized'].includes(transaction.status);
 
     if (shouldVoid) {
+      if (this.options.disableVoidTransactions) {
+        this.logger.error(
+          `Braintree transaction with ID ${transaction.id} cannot be refunded right now because it's in status ${transaction.status}`,
+        );
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Braintree transaction with ID ${transaction.id} cannot be refunded right now`,
+        );
+      }
+
       const cancelResponse = await this.gateway.transaction.void(transaction.id);
 
       if (isBraintreeFailureResponse(cancelResponse)) {

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/types/index.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/types/index.ts
@@ -19,6 +19,12 @@ export interface BraintreeOptions extends Braintree.ClientGatewayConfig {
   disableVoidTransactions?: boolean;
   /** When true, logs important operations to the console for debugging. */
   logging?: boolean;
+  /**
+   * Sandbox only. When true, refundPayment settles the transaction via the
+   * Braintree testing API before refunding (exercises refund vs void path).
+   * Ignored outside sandbox. Default: false.
+   */
+  testForceSettled?: boolean;
 }
 
 export const PaymentProviderKeys = {

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/types/index.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/types/index.ts
@@ -11,6 +11,12 @@ export interface BraintreeOptions extends Braintree.ClientGatewayConfig {
   webhookSecret: string;
   autoCapture: boolean;
   allowRefundOnRefunded?: boolean;
+  /**
+   * When true, refundPayment never voids. Only settled/settling transactions may be refunded.
+   * Late requirement so future partial order refunds and order edits can be supported
+   * (void cancels the full authorization).
+   */
+  disableVoidTransactions?: boolean;
   /** When true, logs important operations to the console for debugging. */
   logging?: boolean;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Braintree configuration option to prevent refunds from voiding unsettled transactions.
  * Refunds now require transactions to be settled or settling when this option is enabled.
  * Added clearer refund history handling and improved webhook transaction processing.

* **Bug Fixes**
  * Refund attempts that cannot be processed now return a structured validation error.
  * Improved handling of missing, invalid, or unsupported Braintree transaction data.

* **Documentation**
  * Updated Braintree setup and upgrade documentation with the new refund behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->