### PR TITLE
chore(braintree): bump package version to 0.2.1

### DIFF
--- a/plugins/braintree-payment/package.json
+++ b/plugins/braintree-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/medusa-payment-braintree",
-  "version": "0.2.0-next",
+  "version": "0.2.1",
   "description": "Braintree plugin for Medusa",
   "author": "Lambda Curry (https://lambdacurry.dev)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `@lambdacurry/medusa-payment-braintree` from `0.2.0-next` to `0.2.1` so the latest refund/void work can be published to npm.
- No other code changes; publish workflow will release the new version on merge to `main`.

## Test plan
- [ ] Confirm `plugins/braintree-payment/package.json` version is `0.2.1`
- [ ] After merge, confirm CI publishes `@lambdacurry/medusa-payment-braintree@0.2.1`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Braintree payment package to version 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->