### PR TITLE
Release stable version 0.2.2

### DIFF
--- a/plugins/braintree-payment/CHANGELOG.md
+++ b/plugins/braintree-payment/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 0.2.0-next
+## 0.2.2
 
 ### Fixes
 
-- Keep refund/void history on `braintreeRefunds[]` (same key as 0.1.8). Read leftover `braintreeRefund` arrays from the 0.2.0-next regression and migrate them onto `braintreeRefunds` on the next refund so both keys cannot drift.
+- Keep refund/void history on `braintreeRefunds[]` (same key as 0.1.8). Read leftover `braintreeRefund` arrays from the brief `0.2.0-next` regression and migrate them onto `braintreeRefunds` on the next refund so both keys cannot drift.
+
+### Notes
+
+- Stable release of the former `0.2.0-next` prerelease. Prefer `0.2.2` (or later) over any `next` dist-tag install.
 
 ### Improvements
 

--- a/plugins/braintree-payment/README.md
+++ b/plugins/braintree-payment/README.md
@@ -153,7 +153,7 @@ Earlier README examples used `logging: process.env.NODE_ENV !== 'production'` (a
 > - `savePaymentMethod`: If set to `true`, customer payment methods are saved for future use.
 > - `allowRefundOnRefunded`: If set to `true`, the imported payment provider will gracefully handle refund attempts on transactions that have already been refunded in Braintree. Instead of throwing an error, it will log a warning and record the refund locally only. This is useful when orders are imported and later refunded directly in Braintree.
 
-### Upgrading to 0.2.0-next
+### Upgrading to 0.2.2
 
 > **Note:**
 > - `disableVoidTransactions`: Late additional requirement so future partial order refunds and order edits can be supported. When `true`, only `settled`/`settling` may be refunded; `authorized`/`submitted_for_settlement` fail with `INVALID_DATA` (“cannot be refunded right now”); other statuses fail with `NOT_FOUND` (“cannot be refunded”). `cancelPayment` may still void.

--- a/plugins/braintree-payment/package.json
+++ b/plugins/braintree-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/medusa-payment-braintree",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Braintree plugin for Medusa",
   "author": "Lambda Curry (https://lambdacurry.dev)",
   "license": "MIT",

--- a/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
+++ b/plugins/braintree-payment/src/providers/payment-braintree/src/core/braintree-base.ts
@@ -1111,7 +1111,7 @@ class BraintreeBase extends AbstractPaymentProvider<BraintreeOptions> {
   /**
    * Reads refund/void history from session data.
    * Prefers `braintreeRefunds` (0.1.8+). Falls back to an array on `braintreeRefund`
-   * (0.2.0-next regression). Non-array values on either key are discarded.
+   * (0.2.0-next / pre-0.2.2 regression). Non-array values on either key are discarded.
    * @param data - Payment session `data` bag
    */
   private readRefundHistory(data: Record<string, unknown> | undefined): BraintreeRefundHistoryEntry[] {


### PR DESCRIPTION
1. **Published** `@lambdacurry/medusa-payment-braintree@0.2.2` as `latest`
2. **Removed** the `next` dist-tag (no more `npm i …@next`)
3. **Deprecated** `0.2.0-next` with a message pointing people to `latest` (`0.2.2+`)

npm now has: `latest → 0.2.2`, `beta → 0.0.18-beta.1`. The `0.2.0-next` tarball still exists (npm doesn’t delete versions) but installs of it show the deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released Braintree Payment version 0.2.2 as the stable successor to the prerelease version.
* **Bug Fixes**
  * Includes the refund-history migration fix for affected prerelease versions.
* **Documentation**
  * Updated upgrade guidance to recommend version 0.2.2 or later.
  * Clarified the refund-history regression range and migration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->