### PR TITLE
Release Braintree plugin 0.2.5

### DIFF
--- a/plugins/braintree-payment/CHANGELOG.md
+++ b/plugins/braintree-payment/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.5
+
+### Fixes
+
+- Keep the original Braintree sale on session `data.transaction` after each refund or void so sequential partial refunds still target that sale id. Gateway credits and voided records live only on `braintreeRefunds[]`.
+- Include the transaction status on refund rejection errors (`cannot be refunded right now because it's in status …` and `cannot be refunded because it's in status …`) instead of logging status separately.
+
+### Notes
+
+- `0.2.4` on npm already includes these runtime fixes (published from #48 without changelog notes). Prefer `0.2.5` for the documented release.
+
 ## 0.2.2
 
 ### Fixes

--- a/plugins/braintree-payment/README.md
+++ b/plugins/braintree-payment/README.md
@@ -153,6 +153,12 @@ Earlier README examples used `logging: process.env.NODE_ENV !== 'production'` (a
 > - `savePaymentMethod`: If set to `true`, customer payment methods are saved for future use.
 > - `allowRefundOnRefunded`: If set to `true`, the imported payment provider will gracefully handle refund attempts on transactions that have already been refunded in Braintree. Instead of throwing an error, it will log a warning and record the refund locally only. This is useful when orders are imported and later refunded directly in Braintree.
 
+### Upgrading to 0.2.5
+
+> **Note:**
+> - Sequential partial refunds keep the original sale on `data.transaction`. Credit/void results are recorded only on `braintreeRefunds[]`. If you were reading the latest credit from `data.transaction` after a refund, use `braintreeRefunds` instead.
+> - Refund rejection errors now include the Braintree transaction status in the message.
+
 ### Upgrading to 0.2.2
 
 > **Note:**

--- a/plugins/braintree-payment/package.json
+++ b/plugins/braintree-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/medusa-payment-braintree",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Braintree plugin for Medusa",
   "author": "Lambda Curry (https://lambdacurry.dev)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `@lambdacurry/medusa-payment-braintree` from `0.2.4` to `0.2.5`.
- Document the sequential partial-refund sale-id fix and status-in-error-message change that landed in #48 (published as `0.2.4` without changelog notes).
- Add README upgrading notes for `0.2.5`.

Merging to `main` publishes `0.2.5` via the existing npm workflow.

## Test plan
- [ ] Confirm changelog and README upgrading notes match the #48 refund behavior.
- [ ] After merge, confirm GitHub Actions “Publish Packages” publishes `@lambdacurry/medusa-payment-braintree@0.2.5`.
- [ ] `npm view @lambdacurry/medusa-payment-braintree version` shows `0.2.5`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented improvements to Braintree refund and void transaction handling.
  * Clarified that sequential partial refunds preserve the original sale while refund results are recorded separately.
  * Added transaction status details to refund rejection error documentation.
* **Release**
  * Updated the Braintree payment plugin to version 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->